### PR TITLE
Lagt til tekstbasert ui for usecasene

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,77 @@
+from usecases import (
+    setup_database,
+    booking_trening,
+    registrer_oppmote,
+    vis_ukeplan,
+    vis_historikk,
+    svartelist_bruker,
+    mest_aktive,
+    trener_sammen,
+)
+
+
+def print_meny():
+    print("\n--- TreningDB ---")
+    print("1. Setup database")
+    print("2. Booking av gruppetime")
+    print("3. Registrere oppmøte")
+    print("4. Vise ukeplan")
+    print("5. Vise personlig treningshistorikk")
+    print("6. Svarteliste bruker")
+    print("7. Månedens mest aktive medlemmer")
+    print("8. Finne brukere som trener sammen")
+    print("0. Avslutt")
+
+
+def main():
+    while True:
+        print_meny()
+        valg = input("Velg et alternativ: ").strip()
+
+        if valg == "1":
+            setup_database()
+
+        elif valg == "2":
+            epost = input("Oppgi e-post: ").strip()
+            gruppetime_id = input("Oppgi gruppetime-ID: ").strip()
+            booking_trening(epost, gruppetime_id)
+
+        elif valg == "3":
+            epost = input("Oppgi e-post: ").strip()
+            gruppetime_id = input("Oppgi gruppetime-ID: ").strip()
+            registrer_oppmote(epost, gruppetime_id)
+
+        elif valg == "4":
+            fra_dato = input("Oppgi fra-dato (YYYY-MM-DD): ").strip()
+            til_dato = input("Oppgi til-dato (YYYY-MM-DD): ").strip()
+            vis_ukeplan(fra_dato, til_dato)
+
+        elif valg == "5":
+            epost = input("Oppgi e-post: ").strip()
+            fra_dato = input("Oppgi fra-dato (YYYY-MM-DD): ").strip()
+            vis_historikk(epost, fra_dato)
+
+        elif valg == "6":
+            epost = input("Oppgi e-post: ").strip()
+            svartelist_bruker(epost)
+
+        elif valg == "7":
+            aar = input("Oppgi år (YYYY): ").strip()
+            maaned = input("Oppgi måned (1-12): ").strip()
+            mest_aktive(aar, maaned)
+
+        elif valg == "8":
+            epost1 = input("Oppgi e-post til første bruker: ").strip()
+            epost2 = input("Oppgi e-post til andre bruker: ").strip()
+            trener_sammen(epost1, epost2)
+
+        elif valg == "0":
+            print("Avslutter programmet.")
+            break
+
+        else:
+            print("Ugyldig valg. Prøv igjen.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/usecases.py
+++ b/src/usecases.py
@@ -1,0 +1,30 @@
+def setup_database():
+    print("Setup database er ikke implementert ennå.")
+
+
+def booking_trening(epost, gruppetime_id):
+    print(f"Booking av gruppetime {gruppetime_id} for {epost} er ikke implementert ennå.")
+
+
+def registrer_oppmote(epost, gruppetime_id):
+    print(f"Registrering av oppmøte for {epost} på gruppetime {gruppetime_id} er ikke implementert ennå.")
+
+
+def vis_ukeplan(fra_dato, til_dato):
+    print(f"Viser ukeplan fra {fra_dato} til {til_dato}.")
+
+
+def vis_historikk(epost, fra_dato):
+    print(f"Viser historikk for {epost} fra {fra_dato}.")
+
+
+def svartelist_bruker(epost):
+    print(f"Svartelisting for {epost} er ikke implementert ennå.")
+
+
+def mest_aktive(aar, maaned):
+    print(f"Viser mest aktive medlemmer for {maaned}/{aar}.")
+
+
+def trener_sammen(epost1, epost2):
+    print(f"Sjekker om {epost1} og {epost2} trener sammen.")


### PR DESCRIPTION
## Legger til enkelt CLI-grensesnitt

Denne PR-en legger til et enkelt tekstbasert grensesnitt for applikasjonen.

Grensesnittet:
- viser en meny med alle usecasene
- lar brukeren velge handling via terminalen
- spør etter nødvendige parametere (f.eks. epost, gruppetime_id, dato)
- kaller tilhørende funksjoner i `usecases.py`

Denne PR-en implementerer **kun UI/brukerinteraksjon**.  
Selve logikken og SQL-spørringene vil bli implementert i senere PR-er.

### Filer
- `src/main.py` – CLI-meny og input fra bruker
- `src/usecases.py` – placeholder-funksjoner for usecases